### PR TITLE
Update Supabase CLI install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,8 @@ RUN corepack enable && corepack prepare pnpm@8.6.12 --activate
 RUN curl -fsSL https://bun.sh/install | bash
 
 # Install Supabase CLI
-RUN curl -sL https://github.com/supabase/cli/releases/download/v1.138.3/supabase_1.138.3_linux_amd64.tar.gz | tar -xvz && \
-    mv supabase /usr/local/bin/
+RUN curl -sL https://github.com/supabase/cli/releases/download/v1.138.3/supabase_1.138.3_linux_amd64.tar.gz \
+    | tar -xz && mv supabase /usr/local/bin/
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
## Summary
- update Supabase CLI installation command

## Testing
- `curl -L -o supabase.tar.gz https://github.com/supabase/cli/releases/download/v1.138.3/supabase_1.138.3_linux_amd64.tar.gz` *(fails: gzip not in format)*


------
https://chatgpt.com/codex/tasks/task_e_68681b71457c83289a37584102055223