### PR TITLE
Fix Supabase CLI install in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,11 @@ RUN corepack enable && corepack prepare pnpm@8.6.12 --activate
 RUN curl -fsSL https://bun.sh/install | bash
 
 # Install Supabase CLI
-RUN curl -sL https://github.com/supabase/cli/releases/download/v1.138.3/supabase_1.138.3_linux_amd64.tar.gz \
-    | tar -xz && mv supabase /usr/local/bin/
+RUN curl -sL https://github.com/supabase/cli/releases/download/v1.138.3/supabase_1.138.3_checksums.txt -o checksums.txt && \
+    curl -sL https://github.com/supabase/cli/releases/download/v1.138.3/supabase_linux_amd64.tar.gz -o supabase_linux_amd64.tar.gz && \
+    grep supabase_linux_amd64.tar.gz checksums.txt | sha256sum -c - && \
+    tar -xzf supabase_linux_amd64.tar.gz && mv supabase /usr/local/bin/ && \
+    rm supabase_linux_amd64.tar.gz checksums.txt
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
## Summary
- fix Supabase CLI download URL in `.devcontainer/Dockerfile`
- verify the tarball checksum before extracting

## Testing
- `bash .devcontainer/check-setup.sh` *(fails: supabase command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681e1dbc308328b18a6acec381a56f