### PR TITLE
Implement optimistic conversation UI

### DIFF
--- a/__tests__/ChatWindow.optimistic.test.tsx
+++ b/__tests__/ChatWindow.optimistic.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+const mockSend = vi
+  .fn()
+  .mockResolvedValueOnce({ id: '1', content: 'Hi there' })
+  .mockResolvedValueOnce({ id: '2', content: 'Second' });
+
+vi.mock('../src/app/hooks/useChat', () => ({
+  useChat: () => ({ sendPrompt: mockSend, isLoading: false }),
+  __esModule: true,
+}));
+
+import ChatWindow from '../src/app/chat/ChatWindow';
+
+describe('ChatWindow optimistic UI', () => {
+  it('replaces placeholders with responses in order', async () => {
+    render(<ChatWindow />);
+
+    const textarea = screen.getByLabelText(/prompt/i);
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    await screen.findByText('…');
+    await screen.findByText('Hi there');
+
+    fireEvent.change(textarea, { target: { value: 'next' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    await screen.findByText('Second');
+
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('hello');
+    expect(items[1]).toHaveTextContent('Hi there');
+    expect(items[2]).toHaveTextContent('next');
+    expect(items[3]).toHaveTextContent('Second');
+  });
+});

--- a/__tests__/conversationReducer.test.ts
+++ b/__tests__/conversationReducer.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { conversationReducer, initialState } from '../src/app/chat/conversationReducer';
+
+describe('conversationReducer', () => {
+  it('maintains ordering for multiple prompts', () => {
+    let state = initialState;
+    state = conversationReducer(state, { type: 'ADD_USER', id: 'u1', content: 'hi' });
+    state = conversationReducer(state, { type: 'ADD_BOT_PLACEHOLDER', userId: 'u1' });
+    state = conversationReducer(state, { type: 'ADD_USER', id: 'u2', content: 'hey' });
+    state = conversationReducer(state, { type: 'ADD_BOT_PLACEHOLDER', userId: 'u2' });
+    state = conversationReducer(state, { type: 'RESOLVE_BOT', userId: 'u1', content: '1' });
+    state = conversationReducer(state, { type: 'RESOLVE_BOT', userId: 'u2', content: '2' });
+
+    expect(state.messages).toEqual([
+      { id: 'u1', role: 'user', content: 'hi' },
+      { id: 'u1-bot', role: 'bot', content: '1' },
+      { id: 'u2', role: 'user', content: 'hey' },
+      { id: 'u2-bot', role: 'bot', content: '2' },
+    ]);
+  });
+
+  it('replaces placeholder with error', () => {
+    let state = initialState;
+    state = conversationReducer(state, { type: 'ADD_USER', id: 'u1', content: 'hi' });
+    state = conversationReducer(state, { type: 'ADD_BOT_PLACEHOLDER', userId: 'u1' });
+    state = conversationReducer(state, { type: 'REPLACE_WITH_ERROR', userId: 'u1', content: 'fail' });
+
+    expect(state.messages).toEqual([
+      { id: 'u1', role: 'user', content: 'hi' },
+      { id: 'u1-bot', role: 'error', content: 'fail' },
+    ]);
+  });
+});

--- a/src/app/chat/conversationReducer.ts
+++ b/src/app/chat/conversationReducer.ts
@@ -1,0 +1,58 @@
+import type { ConvState, Msg } from '@/types/chat';
+
+export type Action =
+  | { type: 'ADD_USER'; id: string; content: string }
+  | { type: 'ADD_BOT_PLACEHOLDER'; userId: string }
+  | { type: 'RESOLVE_BOT'; userId: string; content: string }
+  | { type: 'REPLACE_WITH_ERROR'; userId: string; content: string };
+
+export const initialState: ConvState = {
+  messages: [],
+  pending: {},
+};
+
+export function conversationReducer(
+  state: ConvState,
+  action: Action
+): ConvState {
+  switch (action.type) {
+    case 'ADD_USER':
+      return {
+        messages: [
+          ...state.messages,
+          { id: action.id, role: 'user', content: action.content },
+        ],
+        pending: { ...state.pending, [action.id]: true },
+      };
+    case 'ADD_BOT_PLACEHOLDER':
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          { id: `${action.userId}-bot`, role: 'bot', content: '…' },
+        ],
+      };
+    case 'RESOLVE_BOT': {
+      const botId = `${action.userId}-bot`;
+      return {
+        messages: state.messages.map((m) =>
+          m.id === botId ? { ...m, content: action.content } : m
+        ),
+        pending: { ...state.pending, [action.userId]: false },
+      };
+    }
+    case 'REPLACE_WITH_ERROR': {
+      const botId = `${action.userId}-bot`;
+      return {
+        messages: state.messages.map((m) =>
+          m.id === botId
+            ? { id: botId, role: 'error', content: action.content }
+            : m
+        ),
+        pending: { ...state.pending, [action.userId]: false },
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,10 @@
+export type Msg = {
+  id: string;
+  role: 'user' | 'bot' | 'system' | 'error';
+  content: string;
+};
+
+export interface ConvState {
+  messages: Msg[];
+  pending: Record<string, boolean>;
+}


### PR DESCRIPTION
## Summary
- refactor ChatWindow to use a reducer for optimistic updates
- add conversation reducer with per-message pending state
- centralize chat types
- test reducer logic and optimistic rendering behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68686bf60dac832894d7717dce995fca