### PR TITLE
Add tests for runPrompt and chat route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 server/.env
+server/coverage

--- a/README.md
+++ b/README.md
@@ -46,3 +46,19 @@ const { sendPrompt, isLoading, conversation } = useChat();
 This hook depends on the upcoming UI from the L2-3 milestone to render messages.
 ## Polish
 Smooth scrolling, loading spinner and error banner improve overall UX.
+
+## Testing
+
+Run the full unit and integration test suite:
+
+```bash
+pnpm test
+```
+
+To generate a coverage report, use:
+
+```bash
+pnpm test:cov
+```
+
+Open `coverage/index.html` in your browser to view detailed coverage results.

--- a/__tests__/chatRoute.test.ts
+++ b/__tests__/chatRoute.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import cors from '@fastify/cors';
+
+let chatRoutes: typeof import('../server/routes/chat').default;
+import { mockOpenAI } from '../test/helpers/openai';
+import { mockSupabase } from '../test/helpers/supabase';
+
+const fallback = 'The agent is currently overloaded. Please try again later.';
+
+function buildServer() {
+  const app = Fastify();
+  app.register(cors, { origin: (_o, cb) => cb(null, true) });
+  app.register(chatRoutes);
+  return app;
+}
+
+let server: ReturnType<typeof buildServer>;
+
+beforeEach(async () => {
+  delete (global as any).window;
+  vi.useFakeTimers();
+  process.env.OPENAI_API_KEY = 'k';
+  process.env.SUPABASE_URL = 'http://localhost';
+  process.env.SUPABASE_SERVICE_KEY = 'srv';
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  if (server) await server.close();
+  vi.useRealTimers();
+});
+
+describe('POST /api/mcp/chat', () => {
+  it('returns chat response for valid prompt', async () => {
+    mockOpenAI('success');
+    mockSupabase('ok');
+    chatRoutes = (await import('../server/routes/chat')).default;
+    server = buildServer();
+    const resPromise = server.inject({
+      method: 'POST',
+      url: '/api/mcp/chat',
+      payload: { prompt: 'Ping' },
+    });
+    await vi.runAllTimersAsync();
+    const res = await resPromise;
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toEqual({ id: expect.any(String), content: 'Hi' });
+  });
+
+  it('returns 400 for missing prompt', async () => {
+    chatRoutes = (await import('../server/routes/chat')).default;
+    server = buildServer();
+
+    const resPromise = server.inject({ method: 'POST', url: '/api/mcp/chat', payload: {} });
+    await vi.runAllTimersAsync();
+    const res = await resPromise;
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('falls back when openai fails', async () => {
+    mockOpenAI('fail');
+    mockSupabase('ok');
+    chatRoutes = (await import('../server/routes/chat')).default;
+    server = buildServer();
+
+    const resPromise = server.inject({
+      method: 'POST',
+      url: '/api/mcp/chat',
+      payload: { prompt: 'Ping' },
+    });
+    await vi.runAllTimersAsync();
+    const res = await resPromise;
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toEqual({ id: expect.any(String), content: fallback });
+  });
+});

--- a/__tests__/runPrompt.test.ts
+++ b/__tests__/runPrompt.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockOpenAI } from '../test/helpers/openai';
+import { mockSupabase } from '../test/helpers/supabase';
+
+let runPrompt: (prompt: string) => Promise<{ id: string; content: string }>;
+
+beforeEach(() => {
+  delete (global as any).window;
+  vi.useFakeTimers();
+  process.env.OPENAI_API_KEY = 'k';
+  process.env.SUPABASE_URL = 'http://localhost';
+  process.env.SUPABASE_SERVICE_KEY = 'srv';
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function load() {
+  return import('../server/lib/runPrompt').then((m) => (runPrompt = m.runPrompt));
+}
+
+const fallback = 'The agent is currently overloaded. Please try again later.';
+
+describe('runPrompt', () => {
+  it('resolves on first try without logging', async () => {
+    const { createMock } = mockOpenAI('success');
+    const { insertMock } = mockSupabase('ok');
+    await load();
+
+    const promise = runPrompt('hello');
+    await vi.runAllTimersAsync();
+    const res = await promise;
+
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(res).toEqual({ id: expect.any(String), content: 'Hi' });
+  });
+
+  it('retries once on rate limit and logs', async () => {
+    const { createMock } = mockOpenAI('rateLimit');
+    const { insertMock } = mockSupabase('ok');
+    await load();
+
+    const promise = runPrompt('retry');
+    await vi.runAllTimersAsync();
+    const res = await promise;
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ id: expect.any(String), content: 'Hi' });
+  });
+
+  it('returns fallback after three failures', async () => {
+    const { createMock } = mockOpenAI('fail');
+    const { insertMock } = mockSupabase('ok');
+    await load();
+
+    const promise = runPrompt('fail');
+    await vi.runAllTimersAsync();
+    const res = await promise;
+
+    expect(createMock).toHaveBeenCalledTimes(3);
+    expect(insertMock).toHaveBeenCalledTimes(3);
+    expect(res).toEqual({ id: expect.any(String), content: fallback });
+  });
+
+  it('swallows supabase errors and still resolves', async () => {
+    const { createMock } = mockOpenAI('fail');
+    const { insertMock } = mockSupabase('fail');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await load();
+
+    const promise = runPrompt('oops');
+    await vi.runAllTimersAsync();
+    const res = await promise;
+
+    expect(createMock).toHaveBeenCalledTimes(3);
+    expect(insertMock).toHaveBeenCalledTimes(3);
+    expect(errSpy).toHaveBeenCalledWith('[error log failed]', expect.anything());
+    expect(res.content).toBe(fallback);
+    errSpy.mockRestore();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^8.5.0",
-    "fastify": "^4.26.2",
+    "fastify": "^4.29.1",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run --config vitest.config.ts && pnpm -F server test"
+    "test": "vitest run --config vitest.config.ts && pnpm -F server test",
+    "test:cov": "vitest run --coverage --config vitest.config.ts && pnpm -F server test -- --coverage"
   },
   "dependencies": {
     "@fastify/cors": "^8.5.0",
+    "fastify": "^4.26.2",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -27,6 +29,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^1.6.1",
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^8.5.0
         version: 8.5.0
       fastify:
-        specifier: ^4.26.2
+        specifier: ^4.29.1
         version: 4.29.1
       next:
         specifier: 15.3.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fastify/cors':
         specifier: ^8.5.0
         version: 8.5.0
+      fastify:
+        specifier: ^4.26.2
+        version: 4.29.1
       next:
         specifier: 15.3.5
         version: 15.3.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -45,6 +48,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.6(@types/react@19.1.8)
+      '@vitest/coverage-v8':
+        specifier: ^1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.4)(jsdom@26.1.0)(lightningcss@1.30.1))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -130,13 +136,29 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.27.6':
     resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.0':
+    resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -663,6 +685,10 @@ packages:
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -1208,6 +1234,11 @@ packages:
     resolution: {integrity: sha512-2v3erKKmmCyIVvvhI2nF15qEbdBpISTq44m9pyd5gfIJB1PN94oePTLWEd82XUbIbvKhv76xTSeUQSCOGesLeg==}
     cpu: [x64]
     os: [win32]
+
+  '@vitest/coverage-v8@1.6.1':
+    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
+    peerDependencies:
+      vitest: 1.6.1
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -1867,6 +1898,9 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1911,6 +1945,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1961,6 +1999,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -1999,6 +2040,13 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2131,6 +2179,22 @@ packages:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -2293,6 +2357,13 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -2461,6 +2532,9 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -2507,6 +2581,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2882,6 +2960,10 @@ packages:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
 
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
@@ -3140,6 +3222,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
@@ -3203,9 +3288,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
 
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.0
+
   '@babel/runtime@7.27.6': {}
+
+  '@babel/types@7.28.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3557,6 +3655,8 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
+
+  '@istanbuljs/schema@0.1.3': {}
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -4048,6 +4148,25 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.10.1':
     optional: true
+
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@20.19.4)(jsdom@26.1.0)(lightningcss@1.30.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      test-exclude: 6.0.0
+      vitest: 1.6.1(@types/node@20.19.4)(jsdom@26.1.0)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -4950,6 +5069,8 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -5006,6 +5127,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   globals@14.0.0: {}
 
   globalthis@1.0.4:
@@ -5045,6 +5175,8 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-escaper@2.0.2: {}
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
@@ -5081,6 +5213,13 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -5215,6 +5354,27 @@ snapshots:
   isows@1.0.7(ws@8.18.3):
     dependencies:
       ws: 8.18.3
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      debug: 4.4.1
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.1.7:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -5380,6 +5540,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
+
   make-error@1.3.6: {}
 
   math-intrinsics@1.1.0: {}
@@ -5527,6 +5697,10 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -5582,6 +5756,8 @@ snapshots:
       entities: 6.0.1
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -6026,6 +6202,12 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
@@ -6335,6 +6517,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
 
   ws@8.18.3: {}
 

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     setupFiles: ['../vitest.setup.ts'],
     environment: 'node',
+    coverage: {
+      reporter: ['text', 'html'],
+      lines: 80,
+      branches: 80,
+      statements: 80,
+      functions: 80,
+      include: ['lib/runPrompt.ts'],
+      checkCoverage: true,
+    },
   },
 });

--- a/test/helpers/openai.ts
+++ b/test/helpers/openai.ts
@@ -1,0 +1,23 @@
+import { vi } from 'vitest';
+
+type Mode = 'success' | 'fail' | 'rateLimit';
+
+export function mockOpenAI(mode: Mode, content = 'Hi') {
+  const createMock = vi.fn();
+
+  if (mode === 'success') {
+    createMock.mockResolvedValue({ choices: [{ message: { content } }] });
+  } else if (mode === 'fail') {
+    createMock.mockRejectedValue({ status: 500 });
+  } else if (mode === 'rateLimit') {
+    createMock
+      .mockRejectedValueOnce({ status: 429 })
+      .mockResolvedValueOnce({ choices: [{ message: { content } }] });
+  }
+
+  vi.doMock('../../server/lib/openai', () => ({
+    openai: { chat: { completions: { create: createMock } } },
+  }));
+
+  return { createMock };
+}

--- a/test/helpers/supabase.ts
+++ b/test/helpers/supabase.ts
@@ -1,0 +1,19 @@
+import { vi } from 'vitest';
+
+type Mode = 'ok' | 'fail';
+
+export function mockSupabase(mode: Mode) {
+  const insertMock = vi.fn();
+
+  if (mode === 'ok') {
+    insertMock.mockResolvedValue({});
+  } else {
+    insertMock.mockRejectedValue(new Error('insert failed'));
+  }
+
+  vi.doMock('../../server/lib/supabaseAdmin', () => ({
+    supabase: { from: () => ({ insert: insertMock }) },
+  }));
+
+  return { insertMock };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,18 @@ export default defineConfig({
   test: {
     setupFiles: ['./vitest.setup.ts'],
     environment: 'jsdom',
+    environmentMatchGlobs: [
+      ['**/__tests__/runPrompt.test.ts', 'node'],
+      ['**/__tests__/chatRoute.test.ts', 'node'],
+    ],
+    coverage: {
+      reporter: ['text', 'html'],
+      lines: 80,
+      branches: 80,
+      statements: 80,
+      functions: 80,
+      include: ['server/lib/runPrompt.ts', 'server/routes/chat.ts'],
+      checkCoverage: true,
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add unit tests for runPrompt
- add integration tests for chat route
- create OpenAI and Supabase mocking helpers
- enable coverage thresholds and add `test:cov` script
- document running tests

## Testing
- `pnpm test:cov`

------
https://chatgpt.com/codex/tasks/task_e_6869289cb7b0832884a089bf5246fa7e