### PR TITLE
Add deterministic Playwright e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ pnpm test:cov
 ```
 
 Open `coverage/index.html` in your browser to view detailed coverage results.
+
+## E2E tests
+
+```bash
+pnpm test:e2e           # local headless
+USE_OPENAI_STUB=0 pnpm test:e2e  # hit real API
+```

--- a/__tests__/chatRoute.test.ts
+++ b/__tests__/chatRoute.test.ts
@@ -11,7 +11,7 @@ const fallback = 'The agent is currently overloaded. Please try again later.';
 function buildServer() {
   const app = Fastify();
   app.register(cors, { origin: (_o, cb) => cb(null, true) });
-  app.register(chatRoutes);
+  app.register(chatRoutes, { prefix: '/api/mcp' });
   return app;
 }
 

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('user sends prompt and sees bot reply', async ({ page }) => {
+  await page.goto('http://localhost:3000/chat');
+  // fail test on any console error
+  page.on('console', m => { if (m.type() === 'error') test.fail(m.text()); });
+  // interact
+  const input = page.getByRole('textbox', { name: /prompt/i });
+  await input.fill('Hello');
+  await input.press('Enter');
+  await expect(page.getByText('Hello').first()).toBeVisible();
+  await expect(page.getByText('Hi there').first()).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run --config vitest.config.ts && pnpm -F server test",
-    "test:cov": "vitest run --coverage --config vitest.config.ts && pnpm -F server test -- --coverage"
+    "test:cov": "vitest run --coverage --config vitest.config.ts && pnpm -F server test -- --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ci": "playwright test --reporter=list"
   },
   "dependencies": {
     "@fastify/cors": "^8.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  timeout: 30_000,
+  testDir: './e2e',
+  use: { browserName: 'chromium', headless: true },
+  webServer: [
+    {
+      command: 'pnpm --filter server dev',
+      env: { USE_OPENAI_STUB: '1' },
+      url: 'http://localhost:5001/healthz',
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: 'pnpm dev',
+      url: 'http://localhost:3000',
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import Fastify from 'fastify';
 import cors        from '@fastify/cors';
 import chatRoutes  from './routes/chat';
+import healthRoutes from './routes/healthz';
 import { supabase } from './lib/supabaseAdmin'
 
 /* async function testInsert() {
@@ -37,6 +38,7 @@ await fastify.register(cors, {
 /* ---------------------------- */
 
 fastify.register(chatRoutes, { prefix: '/api/mcp' });
+fastify.register(healthRoutes);
 
 fastify.listen({ port: 5001, host: '0.0.0.0' }, err => {
   if (err) throw err;

--- a/server/lib/runPrompt.ts
+++ b/server/lib/runPrompt.ts
@@ -1,5 +1,3 @@
-import { openai } from './openai';
-import { supabase } from './supabaseAdmin';
 import { webcrypto } from 'node:crypto';
 
 const crypto = webcrypto;
@@ -10,6 +8,11 @@ export interface ChatResponse {
 }
 
 export async function runPrompt(prompt: string): Promise<ChatResponse> {
+  if (process.env.USE_OPENAI_STUB === '1') {
+    return { id: 'stub-1', content: 'Hi there \u{1F44B}' };
+  }
+  const { openai } = await import('./openai');
+  const { supabase } = await import('./supabaseAdmin');
   const retries = [500, 1000, 2000];
 
   for (const delay of retries) {

--- a/server/routes/healthz.ts
+++ b/server/routes/healthz.ts
@@ -1,0 +1,5 @@
+import { FastifyInstance } from 'fastify';
+
+export default async function routes(fastify: FastifyInstance) {
+  fastify.get('/healthz', async () => ({ ok: true }));
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       ['**/__tests__/runPrompt.test.ts', 'node'],
       ['**/__tests__/chatRoute.test.ts', 'node'],
     ],
+    exclude: ['e2e/**'],
     coverage: {
       reporter: ['text', 'html'],
       lines: 80,


### PR DESCRIPTION
## Summary
- stub OpenAI in `runPrompt` when `USE_OPENAI_STUB=1`
- add `/healthz` Fastify route
- start servers in new `playwright.config.ts`
- create Playwright chat spec
- expose e2e scripts and docs
- register health route in server
- exclude e2e from vitest and fix chatRoute tests

## Testing
- `pnpm exec playwright install --with-deps chromium`
- `pnpm test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68693c2aee4083289f58f133c6813205